### PR TITLE
Add TensorRT conversion and Triton docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,28 @@ After adding or modifying data tracked by DVC, upload it with:
 ```bash
 dvc push
 ```
+
+## Triton Inference Server
+
+Convert your ONNX model to TensorRT before serving:
+
+```bash
+python -m crypto_lob_micro_move.cli onnx2trt path/to/model.onnx path/to/model.plan
+```
+
+Run Triton using the provided model repository:
+
+```bash
+docker run --rm -p8000:8000 -p8001:8001 -p8002:8002 \
+    -v $(pwd)/docker/triton/models:/models \
+    nvcr.io/nvidia/tritonserver:23.05-py3 tritonserver --model-repository=/models
+```
+
+Send a sample request:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+    -d '{"inputs":[{"name":"input","shape":[1],"datatype":"FP32","data":[0.0]}]}' \
+    http://localhost:8000/v2/models/micro_move/infer
+```
+

--- a/docker/triton/models/micro_move/config.pbtxt
+++ b/docker/triton/models/micro_move/config.pbtxt
@@ -1,0 +1,17 @@
+name: "micro_move"
+platform: "tensorrt_plan"
+max_batch_size: 0
+input: [
+  {
+    name: "input"
+    data_type: TYPE_FP32
+    dims: [1]
+  }
+]
+output: [
+  {
+    name: "output"
+    data_type: TYPE_FP32
+    dims: [1]
+  }
+]

--- a/src/crypto_lob_micro_move/__init__.py
+++ b/src/crypto_lob_micro_move/__init__.py
@@ -4,5 +4,6 @@ except Exception:  # pragma: no cover - optional dependency
     main = None
 
 from .train import train
+from .tensorrt import convert_onnx_to_trt
 
-__all__ = ["main", "train"]
+__all__ = ["main", "train", "convert_onnx_to_trt"]

--- a/src/crypto_lob_micro_move/cli.py
+++ b/src/crypto_lob_micro_move/cli.py
@@ -1,5 +1,6 @@
 from crypto_lob_micro_move.data import download
 from crypto_lob_micro_move import train as train_module
+from crypto_lob_micro_move.tensorrt import convert_onnx_to_trt
 
 class Commands:
     def download_data(self, output_dir: str = "data/raw"):
@@ -9,6 +10,10 @@ class Commands:
     def train(self, data_dir: str = "data/raw", epochs: int = 1):
         """Run a stub training routine."""
         train_module.train(data_dir=data_dir, epochs=epochs)
+
+    def onnx2trt(self, input_model: str, output_model: str):
+        """Convert an ONNX model to TensorRT."""
+        convert_onnx_to_trt(input_model, output_model)
 
 
 def main():

--- a/src/crypto_lob_micro_move/tensorrt.py
+++ b/src/crypto_lob_micro_move/tensorrt.py
@@ -1,0 +1,8 @@
+import subprocess
+
+
+def convert_onnx_to_trt(input_model: str, output_model: str) -> None:
+    """Convert an ONNX model to TensorRT using the ``onnx2trt`` CLI."""
+    cmd = ["onnx2trt", input_model, "-o", output_model]
+    subprocess.run(cmd, check=True)
+

--- a/tests/test_tensorrt.py
+++ b/tests/test_tensorrt.py
@@ -1,0 +1,9 @@
+from crypto_lob_micro_move.tensorrt import convert_onnx_to_trt
+from unittest import mock
+
+
+def test_convert_onnx_to_trt_calls_subprocess():
+    with mock.patch('subprocess.run') as run:
+        convert_onnx_to_trt('model.onnx', 'model.plan')
+        run.assert_called_with(['onnx2trt', 'model.onnx', '-o', 'model.plan'], check=True)
+


### PR DESCRIPTION
## Summary
- implement an ONNX to TensorRT converter and expose via CLI
- include Triton model repository config
- document running Triton server and converting models
- add tests for converter

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c34350ae8832f9ba9b454df87bb07