### PR TITLE
Add CI workflow with pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit pytest
+      - name: Run pre-commit
+        run: pre-commit run -a
+      - name: Run tests
+        env:
+          PYTHONPATH: src
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add CI workflow
- run `pre-commit run -a` before running tests

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c34c86dc0832fabdfdb0877c78ff2