### PR TITLE
Add dataset configs and CLI dataset selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Download the dataset (requires `kagglehub` credentials) and run the training loo
 
 ```bash
 python -m crypto_lob_micro_move.cli download-data --output_dir data/raw
-python -m crypto_lob_micro_move.cli train --data_dir data/raw --epochs 1
+python -m crypto_lob_micro_move.cli train --data_dir data/raw --dataset btc --epochs 1
 ```
 
-Data is expected under `data/raw`.
+Data is expected under `data/raw/<dataset>` where `<dataset>` can be `btc`, `eth` or `ada`.
 
 ## Production preparation
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -33,10 +33,10 @@ export MLFLOW_TRACKING_URI=http://localhost:5000
 
 ```bash
 python -m crypto_lob_micro_move.cli download-data --output_dir data/raw
-python -m crypto_lob_micro_move.cli train --data_dir data/raw --epochs 1
+python -m crypto_lob_micro_move.cli train --data_dir data/raw --dataset btc --epochs 1
 ```
 
-Данные должны располагаться в каталоге `data/raw`.
+Данные должны располагаться в каталоге `data/raw/<dataset>`, где `<dataset>` может принимать значения `btc`, `eth` или `ada`.
 
 ## Подготовка к продакшену
 

--- a/src/crypto_lob_micro_move/__init__.py
+++ b/src/crypto_lob_micro_move/__init__.py
@@ -3,7 +3,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     main = None
 
-from .train import train
+from .train import train, TrainConfig
 from .tensorrt import convert_onnx_to_trt
 
-__all__ = ["main", "train", "convert_onnx_to_trt"]
+__all__ = ["main", "train", "TrainConfig", "convert_onnx_to_trt"]

--- a/src/crypto_lob_micro_move/cli.py
+++ b/src/crypto_lob_micro_move/cli.py
@@ -7,9 +7,10 @@ class Commands:
         """Download dataset."""
         download.download_data(output_dir)
 
-    def train(self, data_dir: str = "data/raw", epochs: int = 1):
+    def train(self, data_dir: str = "data/raw", dataset: str = "btc", epochs: int = 1):
         """Run a stub training routine."""
-        train_module.train(data_dir=data_dir, epochs=epochs)
+        cfg = train_module.TrainConfig(data_dir=data_dir, dataset=dataset, epochs=epochs)
+        train_module.train(cfg)
 
     def onnx2trt(self, input_model: str, output_model: str):
         """Convert an ONNX model to TensorRT."""

--- a/src/crypto_lob_micro_move/train.py
+++ b/src/crypto_lob_micro_move/train.py
@@ -1,12 +1,31 @@
+from dataclasses import dataclass, asdict
 from pathlib import Path
+from typing import Literal
 
 
-def train(data_dir: str = "data/raw", epochs: int = 1) -> None:
+Dataset = Literal["btc", "eth", "ada"]
+
+
+@dataclass
+class TrainConfig:
+    """Configuration for the training routine."""
+
+    data_dir: str = "data/raw"
+    dataset: Dataset = "btc"
+    epochs: int = 1
+
+    @property
+    def dataset_path(self) -> Path:
+        return Path(self.data_dir) / self.dataset
+
+
+def train(config: TrainConfig = TrainConfig()) -> None:
     """A stub training routine."""
-    data_path = Path(data_dir)
+
+    data_path = config.dataset_path
     if not data_path.exists():
         raise FileNotFoundError(data_path)
-    print(f"Training on {data_path} for {epochs} epochs")
+    print(f"Training on {data_path} for {config.epochs} epochs")
 
 
 if __name__ == "__main__":

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,12 +1,20 @@
-from crypto_lob_micro_move.train import train
-from pathlib import Path
+from crypto_lob_micro_move.train import train, TrainConfig
 
 
 def test_train_raises_for_missing_data(tmp_path):
     missing_dir = tmp_path / "missing"
+    cfg = TrainConfig(data_dir=str(missing_dir), dataset="btc")
     try:
-        train(str(missing_dir))
+        train(cfg)
     except FileNotFoundError:
         assert True
     else:
         assert False, "Expected FileNotFoundError"
+
+
+def test_train_uses_dataset_subdirectory(tmp_path):
+    data_dir = tmp_path / "data"
+    dataset_dir = data_dir / "eth"
+    dataset_dir.mkdir(parents=True)
+    cfg = TrainConfig(data_dir=str(data_dir), dataset="eth")
+    train(cfg)


### PR DESCRIPTION
## Summary
- add `TrainConfig` dataclass with dataset options
- update CLI to compose `TrainConfig`
- document dataset selection in README and README_RU
- test dataset path selection in `train`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c369743ac832fa9f2746d529b15a1